### PR TITLE
Exclude testutils from coverage report

### DIFF
--- a/.github/workflows/qa.yaml
+++ b/.github/workflows/qa.yaml
@@ -59,7 +59,11 @@ jobs:
           go-version-file: go.mod
           cache: true
       - name: Run tests
-        run: go test -coverpkg=./... -coverprofile=/tmp/coverage.out -covermode=count ./...
+        run: |
+          go test -coverpkg=./... -coverprofile=/tmp/coverage.tmp -covermode=count ./...
+
+          # Exclude unwanted files from coverage report
+          grep -hv -e "testutils" /tmp/coverage.tmp > /tmp/coverage.out
       - name: Run tests (with race detector)
         run: |
           go test -race ./...


### PR DESCRIPTION
Test helpers shouldn't belong in coverage. I missed this when porting the workflow from adsys.