### PR TITLE
maint: bump go toolchain to 1.22.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/ubuntu/ubuntu-proxy-manager
 
 go 1.22.0
 
-toolchain go1.22.1
+toolchain go1.22.2
 
 require (
 	github.com/godbus/dbus/v5 v5.1.0

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -2,7 +2,7 @@ module github.com/ubuntu/ubuntu-proxy-manager/tools
 
 go 1.22.0
 
-toolchain go1.22.1
+toolchain go1.22.2
 
 require (
 	github.com/golangci/golangci-lint v1.57.2


### PR DESCRIPTION
Ensure the toolchain will try to use 1.22.2 which has the fix for HTTP/2 CONTINUATION flood in net/http (GO-2024-2687).