### PR TITLE
maint: bump go version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/ubuntu/ubuntu-proxy-manager
 
 go 1.22.0
 
-toolchain go1.22.2
+toolchain go1.22.3
 
 require (
 	github.com/godbus/dbus/v5 v5.1.0


### PR DESCRIPTION
Fixes Vulnerability #1: GO-2024-2824
  Malformed DNS message can cause infinite loop in net
More info: https://pkg.go.dev/vuln/GO-2024-2824
Standard library
  Found in: net@go1.22.2
  Fixed in: net@go1.22.3