### PR TITLE
maint: bump Go toolchain for vulnerability fix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/ubuntu/ubuntu-proxy-manager
 
 go 1.22.0
 
-toolchain go1.22.3
+toolchain go1.22.4
 
 require (
 	github.com/godbus/dbus/v5 v5.1.0

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -2,7 +2,7 @@ module github.com/ubuntu/ubuntu-proxy-manager/tools
 
 go 1.22.0
 
-toolchain go1.22.2
+toolchain go1.22.4
 
 require (
 	github.com/golangci/golangci-lint v1.59.0


### PR DESCRIPTION
Fixes Vulnerability: GO-2024-2887
  The various Is methods (IsPrivate, IsLoopback, etc) did not work as expected
  for IPv4-mapped IPv6 addresses, returning false for addresses which would
  return true in their traditional IPv4 forms.
More info: https://pkg.go.dev/vuln/GO-2024-2887
  Standard library
    Found in: net@go1.21.0
    Fixed in: net@go1.22.4