### PR TITLE
Bump Go toolchain version to 1.23.6

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/ubuntu/ubuntu-proxy-manager
 
 go 1.23.0
 
+toolchain go1.23.6
+
 require (
 	github.com/godbus/dbus/v5 v5.1.0
 	github.com/sirupsen/logrus v1.9.3

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -2,6 +2,8 @@ module github.com/ubuntu/ubuntu-proxy-manager/tools
 
 go 1.23.0
 
+toolchain go1.23.6
+
 require (
 	github.com/golangci/golangci-lint v1.61.0
 	golang.org/x/tools v0.26.0


### PR DESCRIPTION
Fixes vulnerabilities reported by govulncheck