### PR TITLE
Fix invalid golangci-lint config

### DIFF
--- a/.golangci-ci.yaml
+++ b/.golangci-ci.yaml
@@ -42,10 +42,6 @@ issues:
     - 'Error return value of .*Close` is not checked'
   #fix: true # we don’t want this in CI
 
-nolintlint:
-  require-explanation: true
-  require-specific: true
-
 linters-settings:
    # Forbid the usage of deprecated ioutil and debug prints
   forbidigo:

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -41,10 +41,6 @@ issues:
     - 'Error return value of .*Close` is not checked'
   fix: true # we want this in IDE.
 
-nolintlint:
-  require-explanation: true
-  require-specific: true
-
 linters-settings:
    # Forbid the usage of deprecated ioutil and debug prints
   forbidigo:


### PR DESCRIPTION
The nolintlint settings must be part of the "linters-settings" list.
Since the nolintlint linter is not enabled in this config, we just
remove its settings here.

Fixes that golangci-lint fails in the CI with:

    Failed to run: Error: Command failed: /home/runner/golangci-lint-1.63.4-linux-amd64/golangci-lint config verify
    jsonschema: "" does not validate with "/additionalProperties": additional properties 'nolintlint' not allowed
    Failed executing command with error: the configuration contains invalid elements
