### PR TITLE
Bump Go toolchain version to 1.23.10

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/ubuntu/ubuntu-proxy-manager
 
 go 1.23.0
 
-toolchain go1.23.6
+toolchain go1.23.10
 
 require (
 	github.com/godbus/dbus/v5 v5.1.0

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -2,7 +2,7 @@ module github.com/ubuntu/ubuntu-proxy-manager/tools
 
 go 1.23.0
 
-toolchain go1.23.6
+toolchain go1.23.10
 
 require (
 	github.com/golangci/golangci-lint v1.63.4


### PR DESCRIPTION
Fixes vulnerabilities reported by govulncheck